### PR TITLE
Safer & easier to change separator

### DIFF
--- a/clementinemonitor
+++ b/clementinemonitor
@@ -50,6 +50,8 @@ import math
 
 prevout = ""
 
+SEP = "||"
+
 def printifchanged( out ):
   '''Write string to stdout if it is different from the last thing we wrote.
   Will exit if we detect a broken pipe. NOTE: Need to use os._exit as the
@@ -83,7 +85,7 @@ def metatostr( meta ):
   if arturl.startswith("file://"):
     arturl = arturl[7:]
 
-  return str(meta["tracknumber"]) + '|' + meta["title"] + '|' + meta["artist"] + '|' + meta["album"] + '|' + tottime + '|' + meta["location"] + '|' + arturl
+  return str(meta["tracknumber"]) + SEP + meta["title"] + SEP + meta["artist"] + SEP + meta["album"] + SEP + tottime + SEP + meta["location"] + SEP + arturl
 
 def printcurrent():
   '''Get the current status and song data from the player and print it.'''
@@ -94,9 +96,9 @@ def printcurrent():
   else:
     meta = iface.GetMetadata()
     if status == 0:
-      printifchanged("playing|" + metatostr(meta))
+      printifchanged("playing" + SEP + metatostr(meta))
     elif status == 1:
-      printifchanged("paused|" + metatostr(meta))
+      printifchanged("paused" + SEP + metatostr(meta))
 
 def trackchanged(data):
   '''Callback handler for a TrackChange event.'''

--- a/clementinemonitor
+++ b/clementinemonitor
@@ -50,7 +50,7 @@ import math
 
 prevout = ""
 
-SEP = "||"
+SEP = '\t'
 
 def printifchanged( out ):
   '''Write string to stdout if it is different from the last thing we wrote.

--- a/clementinemonitor
+++ b/clementinemonitor
@@ -113,7 +113,14 @@ dbus.mainloop.glib.DBusGMainLoop(set_as_default = True)
 
 session_bus = dbus.SessionBus()
 
-player = session_bus.get_object('org.mpris.clementine', '/Player')
+# Wait until clementine is started
+player = None
+while (player == None):
+    try:
+        player = session_bus.get_object('org.mpris.clementine', '/Player')
+    except Exception:
+        player = None
+
 iface = dbus.Interface(player, dbus_interface='org.freedesktop.MediaPlayer')
 iface.connect_to_signal("TrackChange", trackchanged)
 iface.connect_to_signal("StatusChange", statuschanged)

--- a/clementinemonitor
+++ b/clementinemonitor
@@ -47,10 +47,12 @@ import gobject
 import sys
 import os
 import math
+import time
 
 prevout = ""
 
 SEP = '\t'
+META_KEYS = ["tracknumber", "title", "artist", "album", "location"]
 
 def printifchanged( out ):
   '''Write string to stdout if it is different from the last thing we wrote.
@@ -85,7 +87,16 @@ def metatostr( meta ):
   if arturl.startswith("file://"):
     arturl = arturl[7:]
 
-  return str(meta["tracknumber"]) + SEP + meta["title"] + SEP + meta["artist"] + SEP + meta["album"] + SEP + tottime + SEP + meta["location"] + SEP + arturl
+  # Try to get the other fields, fail gently
+  output = ""
+  for key in META_KEYS:
+    try:
+        output += meta[key] + SEP
+    except Exception:
+        output += "No listed " + key + SEP
+  output += arturl
+  
+  return output
 
 def printcurrent():
   '''Get the current status and song data from the player and print it.'''
@@ -113,13 +124,15 @@ dbus.mainloop.glib.DBusGMainLoop(set_as_default = True)
 
 session_bus = dbus.SessionBus()
 
-# Wait until clementine is started
+# Try until clementine is started
 player = None
 while (player == None):
-    try:
-        player = session_bus.get_object('org.mpris.clementine', '/Player')
-    except Exception:
-        player = None
+  try:
+    player = session_bus.get_object('org.mpris.clementine', '/Player')
+  except Exception:
+    player = None
+    # Sleep when we fail to save resources
+    time.sleep(1)
 
 iface = dbus.Interface(player, dbus_interface='org.freedesktop.MediaPlayer')
 iface.connect_to_signal("TrackChange", trackchanged)

--- a/example/clementineconky
+++ b/example/clementineconky
@@ -21,7 +21,7 @@ on_exit()
 
 trap on_exit EXIT
 
-IFS="|"
+IFS="||"
 clementinemonitor | while read STATUS TRACKNUM TITLE ARTIST ALBUM TOTALTIME FILE ART CRUFT
 do
 

--- a/example/clementineconky
+++ b/example/clementineconky
@@ -21,7 +21,8 @@ on_exit()
 
 trap on_exit EXIT
 
-IFS="||"
+OIFS=$IFS
+IFS=$'\t' #If you changed the symbol in the script, change this. 
 clementinemonitor | while read STATUS TRACKNUM TITLE ARTIST ALBUM TOTALTIME FILE ART CRUFT
 do
 
@@ -62,3 +63,5 @@ do
   # reading a half-written file.
   mv $CONKY_DATA $CONKY_DATA_FINAL
 done
+
+IFS=$OIFS


### PR DESCRIPTION
I have an artist named M|O|O|N in my library, which trashes the output with "|" as a separator. I've changed the default separator to "||" and made it a variable for easy change for others.

Also, thanks for the nice script. It's exactly what I was looking for!
